### PR TITLE
Memoize interpreter

### DIFF
--- a/racket/interpreter.rkt
+++ b/racket/interpreter.rkt
@@ -111,7 +111,7 @@
                [(? list? v) (map interpret-helper v)])))
           (hash-set! interpreter-memo-hash expr out)
           out)))
-  (interpret expr))
+  (interpret-helper expr))
 
 (module+ test
   (require rackunit


### PR DESCRIPTION
This doesn't currently work (not sure why, may be something simple), but memoizing the interpreter should speed things up significantly