### PR TITLE
Run tests on RTML server rather than on GitHub runners

### DIFF
--- a/.github/workflows/run-checks-github-runners.yml
+++ b/.github/workflows/run-checks-github-runners.yml
@@ -70,6 +70,12 @@ jobs:
           cache-to: type=gha,mode=max
           cache-from: type=gha
 
+  # This can be run on ubuntu-latest (i.e., on GitHub's provided runners), but
+  # it will be much slower. Specifically, our end-to-end tests using Verilator
+  # take advantage of the many threads on our machines, whereas the GitHub
+  # machines only have two threads.
+  #
+  # Perhaps we should run this on both?
   run-tests:
     runs-on: self-hosted
     needs: [build-and-push-image, cleaner]


### PR DESCRIPTION
I keep going back and forth on this. I like using GitHub runners because they're very containerized, and if things work on there, then I'm fairly confident they'll work anywhere. Also, it's more secure to not expose our server. However, the tests take unreasonably long on their two-threaded machines, whereas the RTML server has 72 threads.