### PR TITLE
Added llvm_config check in run-tests

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,16 +1,27 @@
 set -e
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-LAKEROAD_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+LAKEROAD_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 declare -rx LAKEROAD_DIR
 
-pushd "$LAKEROAD_DIR" > /dev/null
+if [ -z ${LLVM_CONFIG+x}]; then
+    echo "LLVM_CONFIG is unset"
+    exit 1
+fi
 
-if [ -z ${VERILATOR_INCLUDE_DIR+x} ] ; then
-    verilator --version > /dev/null 2>&1  || { echo >&2 "VERILATOR_INCLUDE_DIR not set.  Aborting."; exit 1; }
+pushd "$LAKEROAD_DIR" >/dev/null
+
+if [ -z ${VERILATOR_INCLUDE_DIR+x} ]; then
+    verilator --version >/dev/null 2>&1 || {
+        echo >&2 "VERILATOR_INCLUDE_DIR not set.  Aborting."
+        exit 1
+    }
     VERILATOR_INCLUDE_DIR="$(realpath "$(dirname "$(which verilator)")"/../share/verilator/include)"
-    [ -d "$VERILATOR_INCLUDE_DIR" ] || { echo >&2 "VERILATOR_INCLUDE_DIR not a directory.  Aborting."; exit 1; }    
+    [ -d "$VERILATOR_INCLUDE_DIR" ] || {
+        echo >&2 "VERILATOR_INCLUDE_DIR not a directory.  Aborting."
+        exit 1
+    }
     declare -rx VERILATOR_INCLUDE_DIR
 fi
 


### PR DESCRIPTION
Add check for LLVM_CONFIG being set at top of `run-tests.sh` (tests currently fail after an hour or so of running if it is not set and this can be checked at invocation time)