### PR TITLE
Update arch. desc. to kill warning

### DIFF
--- a/architecture_descriptions/xilinx_ultrascale_plus.yml
+++ b/architecture_descriptions/xilinx_ultrascale_plus.yml
@@ -45,7 +45,7 @@ implementations:
             { name: S, direction: input, bitwidth: 8, value: S },
             { name: CO, direction: output, bitwidth: 8, value: CO },
             { name: O, direction: output, bitwidth: 8, value: O },
-            { name: CI_TOP, direction:input, bitwidth: 1, value: (bv 0 1) },
+            { name: CI_TOP, direction: input, bitwidth: 1, value: (bv 0 1) },
           ]
         parameters:
           [

--- a/architecture_descriptions/xilinx_ultrascale_plus.yml
+++ b/architecture_descriptions/xilinx_ultrascale_plus.yml
@@ -46,6 +46,12 @@ implementations:
             { name: CO, direction: output, bitwidth: 8, value: CO },
             { name: O, direction: output, bitwidth: 8, value: O },
           ]
+        parameters:
+          [
+            # CARRY_TYPE = "SINGLE"; second carry-in for "DUAL" mode set to 0.
+            { name: CARRY_TYPE, value: (bv 0 1) },
+            { name: CI_TOP, value: (bv 0 1) },
+          ]
     outputs: { O: (get CARRY8 O), CO: (bit 7 (get CARRY8 CO)) }
   - interface: { name: DSP, parameters: { out-width: 48, a-width: 30, b-width: 18, c-width: 48, d-width: 27 } }
     internal_data: {

--- a/architecture_descriptions/xilinx_ultrascale_plus.yml
+++ b/architecture_descriptions/xilinx_ultrascale_plus.yml
@@ -45,12 +45,12 @@ implementations:
             { name: S, direction: input, bitwidth: 8, value: S },
             { name: CO, direction: output, bitwidth: 8, value: CO },
             { name: O, direction: output, bitwidth: 8, value: O },
+            { name: CI_TOP, direction:input, bitwidth: 1, value: (bv 0 1) },
           ]
         parameters:
           [
-            # CARRY_TYPE = "SINGLE"; second carry-in for "DUAL" mode set to 0.
+            # CARRY_TYPE = "SINGLE"; second carry-in for "DUAL" mode set to 0 above.
             { name: CARRY_TYPE, value: (bv 0 1) },
-            { name: CI_TOP, value: (bv 0 1) },
           ]
     outputs: { O: (get CARRY8 O), CO: (bit 7 (get CARRY8 CO)) }
   - interface: { name: DSP, parameters: { out-width: 48, a-width: 30, b-width: 18, c-width: 48, d-width: 27 } }

--- a/integration_tests/lakeroad/xilinx_ultrascale_plus_add16_2_instr.txt
+++ b/integration_tests/lakeroad/xilinx_ultrascale_plus_add16_2_instr.txt
@@ -38,14 +38,18 @@ CHECK:   input [15:0] b;
 CHECK:   wire [15:0] b;
 CHECK:   output [15:0] out;
 CHECK:   wire [15:0] out;
-CHECK:   CARRY8 CARRY8_16 (
+CHECK:   CARRY8 #(
+CHECK      .CARRY_TYPE("SINGLE_CY8")
+CHECK:   ) CARRY8_16 (
 CHECK:     .CI(1'h0),
 CHECK:     .CO(CO_16),
 CHECK:     .DI(a[7:0]),
 CHECK:     .O(out[7:0]),
 CHECK:     .S({ O_7, O_6, O_5, O_4, O_3, O_2, O_1, O_0 })
 CHECK:   );
-CHECK:   CARRY8 CARRY8_17 (
+CHECK:   CARRY8 #(
+CHECK      .CARRY_TYPE("SINGLE_CY8")
+CHECK:   ) CARRY8_17 (
 CHECK:     .CI(CO_16[7]),
 CHECK:     .CO(CO_18),
 CHECK:     .DI(a[15:8]),

--- a/racket/architecture-description.rkt
+++ b/racket/architecture-description.rkt
@@ -1331,7 +1331,8 @@
                                                (module-instance-port "S" "S" 'input 8)
                                                (module-instance-port "CO" "CO" 'output 8)
                                                (module-instance-port "O" "O" 'output 8))
-                                         (list)
+                                         (list (module-instance-parameter "CARRY_TYPE" "(bv 0 1)")
+                                               (module-instance-parameter "CI_TOP" "(bv 0 1)"))
                                          "../verilator_xilinx/CARRY8.v"
                                          "../modules_for_importing/xilinx_ultrascale_plus/CARRY8.v"
                                          "CARRY8"))

--- a/racket/architecture-description.rkt
+++ b/racket/architecture-description.rkt
@@ -1330,9 +1330,9 @@
                                                (module-instance-port "DI" "DI" 'input 8)
                                                (module-instance-port "S" "S" 'input 8)
                                                (module-instance-port "CO" "CO" 'output 8)
-                                               (module-instance-port "O" "O" 'output 8))
-                                         (list (module-instance-parameter "CARRY_TYPE" "(bv 0 1)")
-                                               (module-instance-parameter "CI_TOP" "(bv 0 1)"))
+                                               (module-instance-port "O" "O" 'output 8)
+                                               (module-instance-port "CI_TOP" "(bv 0 1)" 'input 1))
+                                         (list (module-instance-parameter "CARRY_TYPE" "(bv 0 1)"))
                                          "../verilator_xilinx/CARRY8.v"
                                          "../modules_for_importing/xilinx_ultrascale_plus/CARRY8.v"
                                          "CARRY8"))

--- a/racket/compile-to-json.rkt
+++ b/racket/compile-to-json.rkt
@@ -217,7 +217,12 @@
                                                                param))))
                                  [0 "SINGLE_CY8"]
                                  [1 "DUAL_CY4"]
-                                 [_ (error (format "Unexpected CARRY_TYPE ~a" v))])]
+                                 [_
+                                  (error (format "Unexpected CARRY_TYPE ~a"
+                                                 (module-instance-parameter-name
+                                                  (signal-value
+                                                   (lr:bv-v (module-instance-parameter-value
+                                                             param))))))])]
                               [(and (equal? module-name "DSP48E2")
                                     (member (module-instance-parameter-name param)
                                             (list "AMULTSEL"

--- a/racket/compile-to-json.rkt
+++ b/racket/compile-to-json.rkt
@@ -210,6 +210,12 @@
                                 [24 "DYNAMIC"]
                                 [_ (error (format "Unknown Lattice enum value: ~a" v))]))
                             (cond
+                              [(and (equal? module-name "CARRY8")
+                                    (equal? (module-instance-parameter-name param) "CARRY_TYPE"))
+                               (match (bitvector->natural (signal-value (lr:bv-v v)))
+                                 [0 "SINGLE_CY8"]
+                                 [1 "DUAL_CY4"]
+                                 [_ (error (format "Unexpected CARRY_TYPE ~a" v))])]
                               [(and (equal? module-name "DSP48E2")
                                     (member (module-instance-parameter-name param)
                                             (list "AMULTSEL"

--- a/racket/compile-to-json.rkt
+++ b/racket/compile-to-json.rkt
@@ -212,7 +212,9 @@
                             (cond
                               [(and (equal? module-name "CARRY8")
                                     (equal? (module-instance-parameter-name param) "CARRY_TYPE"))
-                               (match (bitvector->natural (signal-value (lr:bv-v v)))
+                               (match (bitvector->natural
+                                       (signal-value (lr:bv-v (module-instance-parameter-value
+                                                               param))))
                                  [0 "SINGLE_CY8"]
                                  [1 "DUAL_CY4"]
                                  [_ (error (format "Unexpected CARRY_TYPE ~a" v))])]


### PR DESCRIPTION
```
WARNING: Not passing all inputs to module semantics, Missing #<set: #:CARRY_TYPE #:CI_TOP>
```

Getting rid of this warning.