### PR TITLE
Fix instruction input args issue

### DIFF
--- a/bin/main.rkt
+++ b/bin/main.rkt
@@ -302,18 +302,10 @@
                     other))]))
 
 (define sketch-inputs
-  (make-sketch-inputs
-   #:output-width output-bitwidth
-   #:data
-   (if (> (length (inputs)) 0)
-       (map (λ (p) (cons (lr:var (car p) (cdr p)) (cdr p))) (inputs))
-       ;;; Handle legacy case where no inputs are given
-       (begin
-         (when (not (instruction))
-           (error "Something's wrong -- no inputs given, but not using legacy instruction input"))
-         (map (lambda (c) (cons (lr:var (~a c) (bvlen c)) (bvlen c))) (symbolics bv-expr))))
-   #:clk (if (clock-name) (cons (lr:var (clock-name) 1) 1) #f)
-   #:rst (if (reset-name) (cons (lr:var (reset-name) 1) 1) #f)))
+  (make-sketch-inputs #:output-width output-bitwidth
+                      #:data (map (λ (p) (cons (lr:var (car p) (cdr p)) (cdr p))) (inputs))
+                      #:clk (if (clock-name) (cons (lr:var (clock-name) 1) 1) #f)
+                      #:rst (if (reset-name) (cons (lr:var (reset-name) 1) 1) #f)))
 (define sketch (first (sketch-generator architecture-description sketch-inputs)))
 (define (exit-timeout e)
   (when (exn:fail:resource? e)

--- a/bin/main.rkt
+++ b/bin/main.rkt
@@ -166,7 +166,7 @@
   [_ (error (format "Unknown solver: ~a" (solver)))])
 
 ;;; Parse instruction. Returns a Racket function in the format currently expected by synthesis:
-;;; A function with keyword arguments, taking signal arguments and returning an association list of 
+;;; A function with keyword arguments, taking signal arguments and returning an association list of
 ;;; signals.
 ;;;
 ;;; expr The instruction to parse, e.g. '(bvadd (var a 8) (var b 8)).

--- a/racket/sketches.rkt
+++ b/racket/sketches.rkt
@@ -59,7 +59,7 @@
 ;;; - clk: (cons lr-expr int) or #f: the expr and bitwidth of the clock, if one exists.
 ;;; - rst: (cons lr-expr int) or #f: the expr and bitwidth of the reset, if one exists.
 ;;; - data: (listof (cons lr-expr int)): the exprs and bitwidths of the data inputs.
-(struct sketch-inputs (output-width clk rst data))
+(struct sketch-inputs (output-width clk rst data) #:transparent)
 (define (make-sketch-inputs #:output-width output-width #:data data #:clk [clk #f] #:rst [rst #f])
   (sketch-inputs output-width clk rst data))
 


### PR DESCRIPTION
Getting errors in the eval from using the legacy --instruction input method.