### PR TITLE
Only pass in inputs on first half of clock cycle

### DIFF
--- a/bin/main.rkt
+++ b/bin/main.rkt
@@ -351,7 +351,8 @@
             ;;; (apply append == flatten once; Racket's `flatten` flattens too much.)
             ;;; First, we tick the clock with the inputs set to their input values.
             [envs (append (list (cons (cons (clock-name) (bv->signal (bv 0 1))) input-values)
-                                (cons (cons (clock-name) (bv->signal (bv 1 1))) input-values))
+                                (cons (cons (clock-name) (bv->signal (bv 1 1)))
+                                      (make-intermediate-inputs (inputs) 0)))
                           ;;; then, we tick the clock with the inputs set to symbolic values.
                           (apply append
                                  (map (lambda (iter)

--- a/misc/verilator_testbench.cc.template
+++ b/misc/verilator_testbench.cc.template
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {{
 #else
     // CLOCK CYCLE 1
 
-    // Set inputs to desired inputs.
+    // First half of clock cycle 1: clk=0, inputs=desired inputs.
     SET_MODULE_INPUTS(test_module, inputs)
     SET_MODULE_CLOCK(test_module, 0)
     SET_MODULE_INPUTS(ground_truth_module, inputs)
@@ -67,7 +67,18 @@ int main(int argc, char** argv) {{
 
     test_module->eval();
     ground_truth_module->eval();
-    
+
+    // Second half of clock cycle 1: clk=1, inputs=random values/0.
+    if ({use_random_intermediate_inputs} == true) {{
+      for (int i = 0; i < NUM_INPUTS; i++) {{
+        inputs[i] = rand();
+      }}
+    }} else {{
+      for (int i = 0; i < NUM_INPUTS; i++) {{
+        inputs[i] = 0;
+      }}
+    }}
+
     SET_MODULE_CLOCK(test_module, 1)
     SET_MODULE_CLOCK(ground_truth_module, 1)
     


### PR DESCRIPTION
This is a pretty significant change. Conceptually, I realized this is "more correct" while implementing #358.

Why is this more correct? Well, let's talk about the times when what we currently have is *incorrect*: It's incorrect for one-cycle synthesis. Currently, if we're synthesizing a one-cycle operation, then we eval with inputs=inputs and clk=0, and we eval with inputs=inputs and clk=1, and then we use that last eval to formulate our synthesis query. But because inputs=inputs and not inputs=0 on the second eval, then the combinational paths will have inputs and not 0. So this means that the synthesis can choose to use the combinational paths, effectively bypassing the need to use the registers in the one-cycle case!

(note that we don't actually use 0 but symbolic values/havoc in the synthesis query and random values in the simulator)

This shouldn't be a problem for combinational cases or for >1 cycle cases.

Why is it correct to pass in the inputs only when clk=0, though? This is because the semantics of registers say that, when a register is at clk=1 and was previously at clk=0, they latch in the value from the previous timestep when clk=0. So effectively, the value at the current timestep does not matter. Thus, we never needed to be passing inputs at the clk=1 timestep!