### PR TITLE
Add Bitwuzla as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lakeroad-private"]
 	path = lakeroad-private
 	url = git@github.com:uwsampl/lakeroad-private
+[submodule "bitwuzla"]
+	path = bitwuzla
+	url = git@github.com:bitwuzla/bitwuzla.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,13 +88,11 @@ WORKDIR /root/lakeroad
 ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-# Build latest bitwuzla.
+# Build Bitwuzla from version tracked in submodule.
 WORKDIR /root
 ARG MAKE_JOBS=2
-ARG BITWUZLA_COMMIT_HASH=80a6041152d131af55f4afcf88707352f277b861
-RUN git clone https://github.com/bitwuzla/bitwuzla \
-  && cd bitwuzla \
-  && git checkout ${BITWUZLA_COMMIT_HASH} \
+ADD bitwuzla bitwuzla
+RUN cd bitwuzla \
   && ./configure.py \
   && cd build \
   && ninja -j${MAKE_JOBS}


### PR DESCRIPTION
Closes #364 

Bitwuzla is under active development and there have been regressions since we've been using it. To keep stuff from randomly breaking (as was happening in #362) we should really tightly control the version of Bitwuzla. Hence, we add it as a submodule. We also need to make sure we use this submodule in the evaluation.