### PR TITLE
Enable wider input bitwidths for inputs coming from the command line in `simulate_with_verilator.py`

### DIFF
--- a/bin/simulate_with_verilator.py
+++ b/bin/simulate_with_verilator.py
@@ -109,6 +109,7 @@ def simulate_with_verilator(
         Path(os.environ["LAKEROAD_DIR"]) / "misc" / "verilator_testbench.sv.template"
     ).read_text()
     testbench_source = testbench_template_source.format(
+        max_input_bitwidth=max([bw for _, bw in module_inputs]),
         test_module_name=test_module_name,
         ground_truth_module_name=ground_truth_module_name,
         test_module_port_list=",".join(

--- a/misc/verilator_testbench.sv.template
+++ b/misc/verilator_testbench.sv.template
@@ -4,7 +4,7 @@ module testbench;
 
 integer num_inputs;
 integer num_test_cases;
-integer inputs[];
+logic [{max_input_bitwidth}-1:0] inputs[];
 
 {test_module_name} simulate_with_verilator_test_module({test_module_port_list});
 {ground_truth_module_name} simulate_with_verilator_ground_truth_module({ground_truth_module_port_list});


### PR DESCRIPTION
This came up in #363.