### PR TITLE
Fix issue with `simulate_with_verilator.py` input parsing

### DIFF
--- a/bin/simulate_with_verilator.py
+++ b/bin/simulate_with_verilator.py
@@ -177,7 +177,7 @@ def simulate_with_verilator(
             )
         print(f"{len(module_inputs)} {len(all_inputs)}", file=f)
         for one_set_of_inputs in all_inputs:
-            print(" ".join([str(x) for x in one_set_of_inputs]), file=f)
+            print(" ".join([str(hex(x)) for x in one_set_of_inputs]), file=f)
 
     # --environment-overrides is a brute-force way to allow users to use CXX=...
     # to override the C++ compiler with an environment variable. Overriding

--- a/misc/verilator_testbench.sv.template
+++ b/misc/verilator_testbench.sv.template
@@ -25,7 +25,7 @@ initial begin
 
   for (int i = 0; i < num_test_cases; i++) begin
     for (int j = 0; j < num_inputs; j++) begin
-      $fscanf(STDIN, "%d\n", inputs[j]);
+      $fscanf(STDIN, "%h\n", inputs[j]);
     end
 
     // First half of clock cycle 0 (inputs=inputs, clock=0)


### PR DESCRIPTION
There was an issue with random test case generation for verilator simulation. This PR is a quick fix to address this.

Specifically, for multi-DSP computations that were wide (96 bits), this surfaced through the generation of numbers being cut off by Verilator's stdin parser. 

The fix was just to read as hex, which would be a smaller number compared to decimal.

Thanks Verilator.

Edit from Gus:
Closes #381 