### PR TITLE
Support STP and Yices2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lakeroad-egglog/yosys"]
 	path = lakeroad-egglog/yosys
 	url = git@github.com:uwsampl/yosys
+[submodule "rosette"]
+	path = rosette
+	url = git@github.com:gussmith23/rosette

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "lakeroad-egglog/yosys"]
 	path = lakeroad-egglog/yosys
 	url = git@github.com:uwsampl/yosys
-[submodule "rosette"]
-	path = rosette
-	url = git@github.com:gussmith23/rosette

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,6 @@ ENV PATH="/root/bitwuzla/build/src/main/:${PATH}"
 
 # Install raco (Racket) dependencies. 
 WORKDIR /root
-ADD rosette/ rosette/
 ARG FMT_COMMIT_HASH=bd44477
 RUN \
   # First, fix https://github.com/racket/racket/issues/2691 by building the
@@ -110,6 +109,7 @@ RUN \
   raco setup --doc-index --force-user-docs \
   # Install packages.
   && raco pkg install --deps search-auto --batch \
+  rosette \
   yaml \
   # Install fmt directly from GitHub. This prevents the version from changing on
   # us unexpectedly.
@@ -117,11 +117,6 @@ RUN \
   && git clone https://github.com/sorawee/fmt \
   && cd fmt \
   && git checkout ${FMT_COMMIT_HASH} \
-  && raco pkg install --deps search-auto --batch \
-  # Install Rosette from submodule.
-  # TODO(@gussmith23): Go back to installing Rosette from package manager once
-  # https://github.com/emina/rosette/pull/273 is merged.
-  && cd /root/rosette \
   && raco pkg install --deps search-auto --batch
 
 # Install Rust

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,7 +158,7 @@ ENV LAKEROAD_PRIVATE_DIR=/root/lakeroad/lakeroad-private
 # Build STP.
 WORKDIR /root
 ENV STP_URL="https://github.com/stp/stp/archive/0510509a85b6823278211891cbb274022340fa5c.tar.gz"
-RUN sudo apt-get install -y git cmake bison flex libboost-all-dev python2 perl && \
+RUN apt-get install -y git cmake bison flex libboost-all-dev python2 perl && \
   wget ${STP_URL} -nv -O stp.tar.gz && \
   mkdir stp && \
   tar xzf stp.tar.gz -C stp --strip-components=1 && \
@@ -176,7 +176,7 @@ ENV PATH="/root/stp/build:${PATH}"
 # Build Yices2.
 WORKDIR /root
 ENV YICES2_URL="https://github.com/SRI-CSL/yices2/archive/e27cf308cffb0ecc6cc7165c10e81ca65bc303b3.tar.gz"
-RUN sudo apt-get install -y gperf && \
+RUN apt-get install -y gperf && \
   wget ${YICES2_URL} -nv -O yices2.tar.gz && \
   mkdir yices2 && \
   tar xvf yices2.tar.gz -C yices2 --strip-components=1 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,13 +162,13 @@ RUN apt-get install -y git cmake bison flex libboost-all-dev python2 perl && \
   wget ${STP_URL} -nv -O stp.tar.gz && \
   mkdir stp && \
   tar xzf stp.tar.gz -C stp --strip-components=1 && \
-  pushd stp && \
+  cd stp && \
   ./scripts/deps/setup-gtest.sh && \
   ./scripts/deps/setup-outputcheck.sh && \
   ./scripts/deps/setup-cms.sh && \
   ./scripts/deps/setup-minisat.sh && \
   mkdir build && \
-  pushd build && \
+  cd build && \
   cmake .. && \
   cmake --build .
 ENV PATH="/root/stp/build:${PATH}"
@@ -180,7 +180,7 @@ RUN apt-get install -y gperf && \
   wget ${YICES2_URL} -nv -O yices2.tar.gz && \
   mkdir yices2 && \
   tar xvf yices2.tar.gz -C yices2 --strip-components=1 && \
-  pushd yices2 && \
+  cd yices2 && \
   autoconf && \
   ./configure && \
   make && \

--- a/bin/lakeroad-portfolio.py
+++ b/bin/lakeroad-portfolio.py
@@ -78,7 +78,7 @@ parser.add_argument(
     "--stp", action=argparse.BooleanOptionalAction, help="Use stp.", default=False
 )
 parser.add_argument(
-    "--yices-smt2", action=argparse.BooleanOptionalAction, help="Use yices2.", default=False
+    "--yices", action=argparse.BooleanOptionalAction, help="Use yices2.", default=False
 )
 parser.add_argument(
     "--boolector",
@@ -143,8 +143,8 @@ if args.boolector:
     solvers_and_flag_sets.append(("boolector", []))
 if args.stp:
     solvers_and_flag_sets.append(("stp", []))
-if args.yices_smt2:
-    solvers_and_flag_sets.append(("yices-smt2", []))
+if args.yices:
+    solvers_and_flag_sets.append(("yices", []))
 assert solvers_and_flag_sets != [], "Must specify at least one solver."
 
 

--- a/bin/lakeroad-portfolio.py
+++ b/bin/lakeroad-portfolio.py
@@ -59,6 +59,7 @@ parser.add_argument(
 parser.add_argument(
     "--cvc5", action=argparse.BooleanOptionalAction, help="Use cvc5.", default=False
 )
+
 parser.add_argument(
     "--cvc5-flag-set",
     type=str,
@@ -72,6 +73,9 @@ parser.add_argument(
     ),
     default=[],
     action="append",
+)
+parser.add_argument(
+    "--stp", action=argparse.BooleanOptionalAction, help="Use cvc5.", default=False
 )
 parser.add_argument(
     "--boolector",
@@ -125,6 +129,8 @@ if args.cvc5:
         )
 if args.boolector:
     solvers_and_flag_sets.append(("boolector", []))
+if args.stp:
+    solvers_and_flag_sets.append(("stp", []))
 assert solvers_and_flag_sets != [], "Must specify at least one solver."
 
 

--- a/bin/lakeroad-portfolio.py
+++ b/bin/lakeroad-portfolio.py
@@ -94,17 +94,14 @@ args, rest = parser.parse_known_args()
 rest = rest[1:] if rest[0] == "--" else rest
 
 
-def _parse_flag_sets(flag_sets: List[str]) -> List[List[str]]:
-    """Parse a list of flag sets.
+def _parse_flag_set(flag_set: str) -> List[str]:
+    """Parse a flag set.
 
     A flag set is a string of the form "<key>=<value>,<key>=<value>,...". This
-    function parses a list of flag sets into a list of lists of strings of the
-    form ["<key>=<value>", "<key>=<value>", ...].
+    function parses a set into a list of strings of the form ["<key>=<value>",
+    "<key>=<value>", ...].
     """
-    out = []
-    for flag_set in flag_sets:
-        out.append(flag_set.split(","))
-    return out
+    return flag_set.split(",")
 
 
 # Build list of solvers to run.
@@ -117,14 +114,14 @@ if args.bitwuzla:
         solvers_and_flag_sets.append(("bitwuzla", []))
     else:
         solvers_and_flag_sets.extend(
-            ("bitwuzla", _parse_flag_sets(set)) for set in args.bitwuzla_flag_set
+            ("bitwuzla", _parse_flag_set(set)) for set in args.bitwuzla_flag_set
         )
 if args.cvc5:
     if len(args.cvc5_flag_set) == 0:
         solvers_and_flag_sets.append(("cvc5", []))
     else:
         solvers_and_flag_sets.extend(
-            ("cvc5", _parse_flag_sets(set)) for set in args.cvc5_flag_set
+            ("cvc5", _parse_flag_set(set)) for set in args.cvc5_flag_set
         )
 if args.boolector:
     solvers_and_flag_sets.append(("boolector", []))

--- a/bin/lakeroad-portfolio.py
+++ b/bin/lakeroad-portfolio.py
@@ -81,20 +81,6 @@ parser.add_argument(
     "--yices-smt2", action=argparse.BooleanOptionalAction, help="Use yices2.", default=False
 )
 parser.add_argument(
-    "--yices-smt2-flag-set",
-    type=str,
-    help=(
-        "Solver flag set to pass to yices-smt2. Each flag set (i.e. each"
-        " separate instance of this flag) will generate a separate instance of"
-        " cvc5. A flag set is a string of the form"
-        ' "<key>=<value>,<key>=<value>,...". If no flag set is specified but'
-        " the solver is enabled by its corresponding flag, there will be a"
-        " single instance of the solver with no flags."
-    ),
-    default=[],
-    action="append",
-)
-parser.add_argument(
     "--boolector",
     action=argparse.BooleanOptionalAction,
     help="Use boolector.",
@@ -157,6 +143,8 @@ if args.boolector:
     solvers_and_flag_sets.append(("boolector", []))
 if args.stp:
     solvers_and_flag_sets.append(("stp", []))
+if args.yices_smt2:
+    solvers_and_flag_sets.append(("yices-smt2", []))
 assert solvers_and_flag_sets != [], "Must specify at least one solver."
 
 

--- a/bin/lakeroad-portfolio.py
+++ b/bin/lakeroad-portfolio.py
@@ -59,7 +59,6 @@ parser.add_argument(
 parser.add_argument(
     "--cvc5", action=argparse.BooleanOptionalAction, help="Use cvc5.", default=False
 )
-
 parser.add_argument(
     "--cvc5-flag-set",
     type=str,
@@ -73,12 +72,9 @@ parser.add_argument(
     ),
     default=[],
     action="append",
-<<<<<<< HEAD
 )
 parser.add_argument(
     "--stp", action=argparse.BooleanOptionalAction, help="Use cvc5.", default=False
-=======
->>>>>>> origin/main
 )
 parser.add_argument(
     "--boolector",

--- a/bin/lakeroad-portfolio.py
+++ b/bin/lakeroad-portfolio.py
@@ -81,6 +81,20 @@ parser.add_argument(
     "--yices-smt2", action=argparse.BooleanOptionalAction, help="Use yices2.", default=False
 )
 parser.add_argument(
+    "--yices-smt2-flag-set",
+    type=str,
+    help=(
+        "Solver flag set to pass to yices-smt2. Each flag set (i.e. each"
+        " separate instance of this flag) will generate a separate instance of"
+        " cvc5. A flag set is a string of the form"
+        ' "<key>=<value>,<key>=<value>,...". If no flag set is specified but'
+        " the solver is enabled by its corresponding flag, there will be a"
+        " single instance of the solver with no flags."
+    ),
+    default=[],
+    action="append",
+)
+parser.add_argument(
     "--boolector",
     action=argparse.BooleanOptionalAction,
     help="Use boolector.",

--- a/bin/lakeroad-portfolio.py
+++ b/bin/lakeroad-portfolio.py
@@ -74,7 +74,10 @@ parser.add_argument(
     action="append",
 )
 parser.add_argument(
-    "--stp", action=argparse.BooleanOptionalAction, help="Use cvc5.", default=False
+    "--stp", action=argparse.BooleanOptionalAction, help="Use stp.", default=False
+)
+parser.add_argument(
+    "--yices-smt2", action=argparse.BooleanOptionalAction, help="Use yices2.", default=False
 )
 parser.add_argument(
     "--boolector",

--- a/bin/main.rkt
+++ b/bin/main.rkt
@@ -33,6 +33,7 @@
          "../racket/signal.rkt"
          "../racket/btor.rkt"
          racket/sandbox)
+
 (define-namespace-anchor anc)
 (define ns (namespace-anchor->namespace anc))
 

--- a/bin/main.rkt
+++ b/bin/main.rkt
@@ -29,7 +29,7 @@
          rosette/solver/smt/cvc4
          rosette/solver/smt/bitwuzla
          rosette/solver/smt/stp
-         rosette/solver/smt/yices-smt2
+         rosette/solver/smt/yices
          "../racket/signal.rkt"
          "../racket/btor.rkt"
          racket/sandbox)
@@ -185,7 +185,7 @@
   ["bitwuzla" (current-solver (bitwuzla #:logic 'QF_BV #:options (solver-flags)))]
   ["boolector" (current-solver (boolector #:logic 'QF_BV #:options (solver-flags)))]
   ["stp" (current-solver (stp #:logic 'QF_BV #:options (solver-flags)))]
-  ["yices-smt2" (current-solver (yices-smt2 #:logic 'QF_BV #:options (solver-flags)))]
+  ["yices" (current-solver (yices #:logic 'QF_BV #:options (solver-flags)))]
   [_ (error (format "Unknown solver: ~a" (solver)))])
 
 ;;; Parse instruction. Returns a Racket function in the format currently expected by synthesis:

--- a/bin/main.rkt
+++ b/bin/main.rkt
@@ -154,7 +154,7 @@
   v
   "Flag to pass to the solver. A string of the form <flag>=<value>. This flag can be specified"
   "multiple times."
-  (match-let* ([(list key value) (string-split v "=")] [key (string->keyword key)])
+  (match-let* ([(list key value) (string-split v "=")] [key (string->symbol key)])
     (when (hash-has-key? (solver-flags) key)
       (error (format "Flag ~a already specified." key)))
     (hash-set! (solver-flags) key value))]

--- a/bin/main.rkt
+++ b/bin/main.rkt
@@ -28,6 +28,7 @@
          rosette/solver/smt/cvc5
          rosette/solver/smt/cvc4
          rosette/solver/smt/bitwuzla
+         rosette/solver/smt/stp
          "../racket/signal.rkt"
          "../racket/btor.rkt"
          racket/sandbox)
@@ -182,6 +183,7 @@
   ["cvc4" (current-solver (cvc4 #:logic 'QF_BV #:options (solver-flags)))]
   ["bitwuzla" (current-solver (bitwuzla #:logic 'QF_BV #:options (solver-flags)))]
   ["boolector" (current-solver (boolector #:logic 'QF_BV #:options (solver-flags)))]
+  ["stp" (current-solver (stp #:logic 'QF_BV #:options (solver-flags)))]
   [_ (error (format "Unknown solver: ~a" (solver)))])
 
 ;;; Parse instruction. Returns a Racket function in the format currently expected by synthesis:

--- a/bin/main.rkt
+++ b/bin/main.rkt
@@ -29,10 +29,10 @@
          rosette/solver/smt/cvc4
          rosette/solver/smt/bitwuzla
          rosette/solver/smt/stp
+         rosette/solver/smt/yices-smt2
          "../racket/signal.rkt"
          "../racket/btor.rkt"
          racket/sandbox)
-
 (define-namespace-anchor anc)
 (define ns (namespace-anchor->namespace anc))
 
@@ -184,6 +184,7 @@
   ["bitwuzla" (current-solver (bitwuzla #:logic 'QF_BV #:options (solver-flags)))]
   ["boolector" (current-solver (boolector #:logic 'QF_BV #:options (solver-flags)))]
   ["stp" (current-solver (stp #:logic 'QF_BV #:options (solver-flags)))]
+  ["yices-smt2" (current-solver (yices-smt2 #:logic 'QF_BV #:options (solver-flags)))]
   [_ (error (format "Unknown solver: ~a" (solver)))])
 
 ;;; Parse instruction. Returns a Racket function in the format currently expected by synthesis:

--- a/integration_tests/lakeroad/xilinx_addmulsub_3_stage_unsigned_18_bit.sv
+++ b/integration_tests/lakeroad/xilinx_addmulsub_3_stage_unsigned_18_bit.sv
@@ -1,6 +1,6 @@
 // RUN: outfile=$(mktemp)
 // RUN: (racket $LAKEROAD_DIR/bin/main.rkt \
-// RUN:  --solver cvc5 \
+// RUN:  --solver stp \
 // RUN:  --verilog-module-filepath %s \
 // RUN:  --architecture xilinx-ultrascale-plus \
 // RUN:  --template dsp \
@@ -19,33 +19,6 @@
 // RUN:  > $outfile \
 // RUN:  2>&1 
 // RUN: FileCheck %s < $outfile
-// if [ -z ${LAKEROAD_PRIVATE_DIR+x} ]; then \
-//   echo "Warning: LAKEROAD_PRIVATE_DIR is not set. Skipping simulation."; \
-//   exit 0; \
-// else \
-//   python3 $LAKEROAD_DIR/bin/simulate_with_verilator.py \
-//    --use_random_intermediate_inputs \
-//    --seed=23 \
-//    --max_num_tests=10000 \
-//    --verilog_filepath $outfile \
-//    --verilog_filepath %s \
-//    --clock_name clk \
-//    --initiation_interval 3 \
-//    --output_signal_name out \
-//    --input_signal a:18 \
-//    --input_signal b:18 \
-//    --input_signal c:18 \
-//    --input_signal d:18 \
-//    --verilator_include_dir "$LAKEROAD_PRIVATE_DIR/DSP48E2/" \
-//    --verilator_extra_arg='-DXIL_XECLIB' \
-//    --verilator_extra_arg='-Wno-UNOPTFLAT' \
-//    --verilator_extra_arg='-Wno-LATCH' \
-//    --verilator_extra_arg='-Wno-WIDTH' \
-//    --verilator_extra_arg='-Wno-STMTDLY' \
-//    --verilator_extra_arg='-Wno-CASEX' \
-//    --verilator_extra_arg='-Wno-TIMESCALEMOD' \
-//    --verilator_extra_arg='-Wno-PINMISSING'; \
-// fi
 
 (* use_dsp = "yes" *) module top(
 	input  [17:0] a,
@@ -68,4 +41,4 @@
 	assign out = stage2;
 endmodule
 
-// CHECK: Synthesis Timeout
+// CHECK: Synthesis failed

--- a/integration_tests/lakeroad/xilinx_muladd_0_stage_unsigned_13_bit.sv
+++ b/integration_tests/lakeroad/xilinx_muladd_0_stage_unsigned_13_bit.sv
@@ -1,6 +1,6 @@
 // RUN: outfile=$(mktemp)
-// RUN: (racket $LAKEROAD_DIR/bin/main.rkt \
-// RUN:  --solver cvc5 \
+// RUN: racket $LAKEROAD_DIR/bin/main.rkt \
+// RUN:  --solver stp \
 // RUN:  --verilog-module-filepath %s \
 // RUN:  --architecture xilinx-ultrascale-plus \
 // RUN:  --template dsp \
@@ -13,35 +13,8 @@
 // RUN:  --input-signal b:13 \
 // RUN:  --input-signal c:13 \
 // RUN:  --timeout 90 \
-// RUN:  || true) \
-// RUN:  > $outfile \
-// RUN:  2>&1
-// FileCheck %s < $outfile
-// if [ -z ${LAKEROAD_PRIVATE_DIR+x} ]; then \
-//   echo "Warning: LAKEROAD_PRIVATE_DIR is not set. Skipping simulation."; \
-//   exit 0; \
-// else \
-//   python $LAKEROAD_DIR/bin/simulate_with_verilator.py \
-//    --use_random_intermediate_inputs \
-//    --seed=23 \
-//    --max_num_tests=10000 \
-//    --verilog_filepath $outfile \
-//    --verilog_filepath %s \
-//    --initiation_interval 0 \
-//    --output_signal_name out \
-//    --input_signal a:13 \
-//    --input_signal b:13 \
-//    --input_signal c:13 \
-//    --verilator_include_dir "$LAKEROAD_PRIVATE_DIR/DSP48E2/" \
-//    --verilator_extra_arg='-DXIL_XECLIB' \
-//    --verilator_extra_arg='-Wno-UNOPTFLAT' \
-//    --verilator_extra_arg='-Wno-LATCH' \
-//    --verilator_extra_arg='-Wno-WIDTH' \
-//    --verilator_extra_arg='-Wno-STMTDLY' \
-//    --verilator_extra_arg='-Wno-CASEX' \
-//    --verilator_extra_arg='-Wno-TIMESCALEMOD' \
-//    --verilator_extra_arg='-Wno-PINMISSING'; \
-// fi
+// RUN:  > $outfile
+// RUN: FileCheck %s < $outfile
 
 (* use_dsp = "yes" *) module top(
 	input  [12:0] a,
@@ -53,4 +26,5 @@
 	assign out = (a * b) + c;
 endmodule
 
-// CHECK: Synthesis Timeout
+// CHECK: module top(a, b, c, out);
+

--- a/integration_tests/lakeroad/xilinx_muladd_3_stage_signed_18_bit.sv
+++ b/integration_tests/lakeroad/xilinx_muladd_3_stage_signed_18_bit.sv
@@ -1,6 +1,6 @@
 // RUN: outfile=$(mktemp)
 // RUN: (racket $LAKEROAD_DIR/bin/main.rkt \
-// RUN:  --solver cvc5 \
+// RUN:  --solver stp \
 // RUN:  --verilog-module-filepath %s \
 // RUN:  --architecture xilinx-ultrascale-plus \
 // RUN:  --template dsp \
@@ -19,32 +19,6 @@
 // RUN:  > $outfile \
 // RUN:  2>&1
 // RUN: FileCheck %s < $outfile
-// if [ -z ${LAKEROAD_PRIVATE_DIR+x} ]; then \
-//   echo "Warning: LAKEROAD_PRIVATE_DIR is not set. Skipping simulation."; \
-//   exit 0; \
-// else \
-//   python3 $LAKEROAD_DIR/bin/simulate_with_verilator.py \
-//    --test_module_name test_module \
-//    --ground_truth_module_name top \
-//    --max_num_tests=10000 \
-//    --verilog_filepath $outfile \
-//    --verilog_filepath %s \
-//    --clock_name clk \
-//    --initiation_interval 3 \
-//    --output_signal out:18 \
-//    --input_signal a:18 \
-//    --input_signal b:18 \
-//    --input_signal c:18 \
-//    --verilator_include_dir "$LAKEROAD_PRIVATE_DIR/DSP48E2/" \
-//    --verilator_extra_arg='-DXIL_XECLIB' \
-//    --verilator_extra_arg='-Wno-UNOPTFLAT' \
-//    --verilator_extra_arg='-Wno-LATCH' \
-//    --verilator_extra_arg='-Wno-WIDTH' \
-//    --verilator_extra_arg='-Wno-STMTDLY' \
-//    --verilator_extra_arg='-Wno-CASEX' \
-//    --verilator_extra_arg='-Wno-TIMESCALEMOD' \
-//    --verilator_extra_arg='-Wno-PINMISSING'; \
-// fi
 
 (* use_dsp = "yes" *) module top(
     input signed [17:0] a,
@@ -67,4 +41,4 @@
   assign out = stage2;
 endmodule
 
-// CHECK: Synthesis Timeout
+// CHECK: Synthesis failed


### PR DESCRIPTION
This PR adds support for STP and Yices2 to improve our portfolio solving.

It adds 

- Match arm branches of solver flag parsing in`main.rkt` that allows the user to pass in STP or Yices2 as the solver.
- Lines in the `lakeroad-portfolio.py` that add stp and yices2 as options for portfolio solving.

Note that this PR doesn't add functionality for passing flags/solver settings to STP or Yices2; we haven't needed them yet.

Closes #406 