### PR TITLE
Add .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,24 @@
+# Template file for setting up environment variables for Lakeroad. We recommend
+# copying this file to .env and filling in the following variables. Then, before
+# developing with Lakeroad, you can run `source .env` to set up the environment.
+
+# Lakeroad's tests depend on LLVM's lit and FileCheck tools. If lit and
+# FileCheck are not on your PATH, then you can set the LLVM_CONFIG variable to
+# the path to the llvm-config binary on your system, e.g.
+# /usr/local/Cellar/llvm/17.0.6_1/bin/llvm-config on macOS with Homebrew.
+export LLVM_CONFIG=
+
+########################## DO NOT EDIT BELOW THIS LINE #########################
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+# Set up path to Lakeroad.
+export LAKEROAD_DIR="$SCRIPT_DIR"
+
+# If lakeroad-private directory isn't empty, set up path to Lakeroad private.
+# Note that we intentionally just use `ls` and not `ls -A`, to avoid getting
+# tricked by hidden files e.g. .DS_Store on Mac. We could use git here, but I
+# really don't love when scripts depend on git being available.
+if [ -n "$(ls "$SCRIPT_DIR/lakeroad-private" )" ]; then
+    export LAKEROAD_PRIVATE_DIR="$SCRIPT_DIR/lakeroad-private"
+fi

--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Please see the [Dockerfile](./Dockerfile)
 
 ## Environment Variables
 
-- `LAKEROAD_DIR`
-- `LAKEROAD_PRIVATE_DIR`
-- `LLVM_CONFIG`
+See [`.env.template`](./.env.template)
+  for information on the environment variables
+  which need to be set
+  for Lakeroad to function properly.
 
 ## Testing in Lakeroad
 


### PR DESCRIPTION
cc @cknizek -- see instructions in the new file. This gives us an easy way to set up the necessary environment variables by simply running `source .env` (once you've copied `.env.template` to `.env` and set the appropriate variables).