### PR TITLE
Fix #507

### DIFF
--- a/integration_tests/lakeroad/xilinx_ultrascale_plus_squarediffmult.sv
+++ b/integration_tests/lakeroad/xilinx_ultrascale_plus_squarediffmult.sv
@@ -10,12 +10,23 @@
 // RUN:  --top-module-name squarediffmult \
 // RUN:  --pipeline-depth 3 \
 // RUN:  --clock-name clk \
-// RUN:  --module-name squarediffmult \
+// RUN:  --module-name squarediffmult_lakeroad \
 // RUN:  --input-signal 'd:(port a 16):16' \
 // RUN:  --input-signal 'a:(port b 16):16' \
 // RUN:  --verilog-module-out-signal square_out:34 \
 // RUN:  --timeout 120 \
-// RUN:  --extra-cycles 1
+// RUN:  --extra-cycles 1 \
+// RUN:  --simulate-with-verilator \
+// RUN:  --simulate-with-verilator-arg "--max_num_tests=10000" \
+// RUN:  --simulate-with-verilator-arg "--verilator_include_dir=$LAKEROAD_PRIVATE_DIR/DSP48E2/" \
+// RUN:  --simulate-with-verilator-arg "--verilator_extra_arg='-DXIL_XECLIB'" \
+// RUN:  --simulate-with-verilator-arg "--verilator_extra_arg='-Wno-UNOPTFLAT'" \
+// RUN:  --simulate-with-verilator-arg "--verilator_extra_arg='-Wno-LATCH'" \
+// RUN:  --simulate-with-verilator-arg "--verilator_extra_arg='-Wno-WIDTH'" \
+// RUN:  --simulate-with-verilator-arg "--verilator_extra_arg='-Wno-STMTDLY'" \
+// RUN:  --simulate-with-verilator-arg "--verilator_extra_arg='-Wno-CASEX'" \
+// RUN:  --simulate-with-verilator-arg "--verilator_extra_arg='-Wno-TIMESCALEMOD'" \
+// RUN:  --simulate-with-verilator-arg "--verilator_extra_arg='-Wno-PINMISSING'" 
 
 module squarediffmult # (parameter SIZEIN = 16)
 (
@@ -40,3 +51,7 @@ end
 assign square_out = m_reg;
 
 endmodule // squarediffmult
+
+// CHECK: module squarediffmult_lakeroad(a, b, clk, square_out);
+// CHECK:   DSP48E2 #(
+// CHECK: endmodule

--- a/integration_tests/lakeroad/xilinx_ultrascale_plus_squarediffmult.sv
+++ b/integration_tests/lakeroad/xilinx_ultrascale_plus_squarediffmult.sv
@@ -1,0 +1,42 @@
+// Squarer support for DSP block (DSP48E2) with pre-adder configured as
+// subtractor
+
+// RUN: racket $LAKEROAD_DIR/bin/main.rkt \
+// RUN:  --solver bitwuzla \
+// RUN:  --verilog-module-filepath %s \
+// RUN:  --architecture xilinx-ultrascale-plus \
+// RUN:  --template dsp \
+// RUN:  --out-format verilog \
+// RUN:  --top-module-name squarediffmult \
+// RUN:  --pipeline-depth 3 \
+// RUN:  --clock-name clk \
+// RUN:  --module-name squarediffmult \
+// RUN:  --input-signal 'd:(port a 16):16' \
+// RUN:  --input-signal 'a:(port b 16):16' \
+// RUN:  --verilog-module-out-signal square_out:33 \
+// RUN:  --timeout 90 \
+// RUN:  --extra-cycles 3
+
+module squarediffmult # (parameter SIZEIN = 16)
+(
+    input clk,
+    input signed [SIZEIN-1:0] a, b,
+    output signed [2*SIZEIN+1:0] square_out
+);
+
+// Declare registers for intermediate values
+reg signed [SIZEIN-1:0] a_reg, b_reg;
+reg signed [SIZEIN:0] diff_reg;
+reg signed [2*SIZEIN+1:0] m_reg;
+
+always @(posedge clk) begin
+    a_reg <= a;
+    b_reg <= b;
+    diff_reg <= a_reg - b_reg;
+    m_reg <= diff_reg * diff_reg;
+end
+
+// Output result
+assign square_out = m_reg;
+
+endmodule // squarediffmult

--- a/integration_tests/lakeroad/xilinx_ultrascale_plus_squarediffmult.sv
+++ b/integration_tests/lakeroad/xilinx_ultrascale_plus_squarediffmult.sv
@@ -13,9 +13,9 @@
 // RUN:  --module-name squarediffmult \
 // RUN:  --input-signal 'd:(port a 16):16' \
 // RUN:  --input-signal 'a:(port b 16):16' \
-// RUN:  --verilog-module-out-signal square_out:33 \
-// RUN:  --timeout 90 \
-// RUN:  --extra-cycles 3
+// RUN:  --verilog-module-out-signal square_out:34 \
+// RUN:  --timeout 120 \
+// RUN:  --extra-cycles 1
 
 module squarediffmult # (parameter SIZEIN = 16)
 (

--- a/integration_tests/lakeroad/xilinx_ultrascale_plus_squarediffmult.sv
+++ b/integration_tests/lakeroad/xilinx_ultrascale_plus_squarediffmult.sv
@@ -2,7 +2,7 @@
 // subtractor
 
 // RUN: racket $LAKEROAD_DIR/bin/main.rkt \
-// RUN:  --solver bitwuzla \
+// RUN:  --solver cvc5 \
 // RUN:  --verilog-module-filepath %s \
 // RUN:  --architecture xilinx-ultrascale-plus \
 // RUN:  --template dsp \

--- a/racket/synthesize.rkt
+++ b/racket/synthesize.rkt
@@ -955,6 +955,11 @@
               [final-value (foldl interpret-one-iter (list (signal 'unused '())) envs)])
          (cdr (reverse (map signal-value final-value))))]))
 
+  (log-debug "bv-expr-evaluated: ~a" bv-expr-evaluated)
+  (log-debug "lr-expr-evaluated: ~a" lr-expr-evaluated)
+  (log-debug "(last bv-expr-evaluated): ~a" (last bv-expr-evaluated))
+  (log-debug "(last lr-expr-evaluated): ~a" (last lr-expr-evaluated))
+
   ;;; This block of code should be restructured. Instead of running synthesis in here, this `define`
   ;;; should interpret the Lakeroad expression, and then synthesis should be moved to another define.
   (define soln

--- a/racket/synthesize.rkt
+++ b/racket/synthesize.rkt
@@ -955,11 +955,6 @@
               [final-value (foldl interpret-one-iter (list (signal 'unused '())) envs)])
          (cdr (reverse (map signal-value final-value))))]))
 
-  (log-debug "bv-expr-evaluated: ~a" bv-expr-evaluated)
-  (log-debug "lr-expr-evaluated: ~a" lr-expr-evaluated)
-  (log-debug "(last bv-expr-evaluated): ~a" (last bv-expr-evaluated))
-  (log-debug "(last lr-expr-evaluated): ~a" (last lr-expr-evaluated))
-
   ;;; This block of code should be restructured. Instead of running synthesis in here, this `define`
   ;;; should interpret the Lakeroad expression, and then synthesis should be moved to another define.
   (define soln


### PR DESCRIPTION
Closes #507 

Adds test showing ability to do `(d-a)^2`



While debugging, it was useful to hardcode some values to try and get this to work:
```diff
modified   architecture_descriptions/xilinx_ultrascale_plus.yml
@@ -248,7 +248,7 @@ implementations:
 
             { name: CLK, direction: input, bitwidth: 1, value: clk },
             { name: D, direction: input, bitwidth: 27, value: (choose D (extract 26 0 C)) },
-            { name: INMODE, direction: input, bitwidth: 5, value: INMODE },
+            { name: INMODE, direction: input, bitwidth: 5, value: "(bv #b01100 5)" },
             { name: MULTSIGNIN, direction: input, bitwidth: 1, value: (bv 0 1) },
             { name: OPMODE, direction: input, bitwidth: 9, value: OPMODE },
             { name: PCIN, direction: input, bitwidth: 48, value: (choose (zero-extend C (bitvector 48)) (bv 0 48)) },
@@ -268,10 +268,10 @@ implementations:
         parameters: [
           # Set to AREG given that we don't use cascade paths.
           { name: ACASCREG, value: (zero-extend AREG (bitvector 32)) },
-          { name: ADREG, value: (zero-extend ADREG (bitvector 32)) },
+          { name: ADREG, value: (zero-extend (bv 1 1) (bitvector 32)) },
           { name: ALUMODEREG, value: (zero-extend ALUMODEREG (bitvector 32)) },
           { name: AMULTSEL, value: (choose (bv 0 5) (bv 2 5)) },
-          { name: AREG, value: (zero-extend AREG (bitvector 32))},
+          { name: AREG, value: (zero-extend (bv 1 1) (bitvector 32))},
           # NO_RESET
           { name: AUTORESET_PATDET, value: (bv 3 5) },
           # RESET
@@ -287,7 +287,7 @@ implementations:
           { name: CARRYINREG, value: (bv 0 32) },
           { name: CARRYINSELREG, value: (zero-extend CARRYINSELREG (bitvector 32)) },
           { name: CREG, value: (zero-extend CREG (bitvector 32)) },
-          { name: DREG, value: (zero-extend DREG (bitvector 32)) },
+          { name: DREG, value: (zero-extend (bv 1 1) (bitvector 32)) },
           { name: INMODEREG, value: (zero-extend INMODEREG (bitvector 32)) },
           { name: IS_ALUMODE_INVERTED, value: (bv 0 4) },
           { name: IS_CARRYIN_INVERTED, value: (bv 0 1) },
@@ -305,7 +305,7 @@ implementations:
           { name: IS_RSTM_INVERTED, value: (bv 0 1) },
           { name: IS_RSTP_INVERTED, value: (bv 0 1) },
           { name: MASK, value: (bv 0 48) },
-          { name: MREG, value: (zero-extend MREG (bitvector 32)) },
+          { name: MREG, value: (zero-extend (bv 1 1) (bitvector 32)) },
           { name: OPMODEREG, value: (zero-extend OPMODEREG (bitvector 32)) },
           { name: PATTERN, value: (bv 0 48) },
           # A
```
most notable being `INMODE`, which I set using Table 2-2 in the DSP manual.